### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -53,11 +53,11 @@ class HttpNtlmAuth(AuthBase):
         request = response.request.copy()
 
         # initial auth header with username. will result in challenge
-        msg = "%s\\%s" % (self.domain, self.username) if self.domain else self.username
+        msg = "{0!s}\\{1!s}".format(self.domain, self.username) if self.domain else self.username
 
         # ntlm returns the headers as a base64 encoded bytestring. Convert to
         # a string.
-        auth = 'NTLM %s' % ntlm.create_NTLM_NEGOTIATE_MESSAGE(msg).decode('ascii')
+        auth = 'NTLM {0!s}'.format(ntlm.create_NTLM_NEGOTIATE_MESSAGE(msg).decode('ascii'))
         request.headers[auth_header] = auth
 
         # A streaming response breaks authentication.
@@ -98,10 +98,10 @@ class HttpNtlmAuth(AuthBase):
 
         # ntlm returns the headers as a base64 encoded bytestring. Convert to a
         # string.
-        auth = 'NTLM %s' % ntlm.create_NTLM_AUTHENTICATE_MESSAGE(
+        auth = 'NTLM {0!s}'.format(ntlm.create_NTLM_AUTHENTICATE_MESSAGE(
             ServerChallenge, self.username, self.domain, self.password,
             NegotiateFlags
-        ).decode('ascii')
+        ).decode('ascii'))
         request.headers[auth_header] = auth
 
         response3 = response2.connection.send(request, **args)

--- a/requests_ntlm/requests_ntlmsspi.py
+++ b/requests_ntlm/requests_ntlmsspi.py
@@ -48,7 +48,7 @@ class HttpNtlmSspiAuth(AuthBase):
         """
         challenge = challenge.decode('base64') if challenge else None
         _, output_buffer = self.AuthGen.authorize(challenge)
-        return 'NTLM %s' % output_buffer[0].Buffer.encode('base64').replace('\n', '')
+        return 'NTLM {0!s}'.format(output_buffer[0].Buffer.encode('base64').replace('\n', ''))
 
     def new_request(self, response):
         response.content

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,12 +2,12 @@ from flask import Flask,request
 from ntlm3 import ntlm
 app = Flask(__name__)
 
-REQUEST_2 = 'NTLM %s' % ntlm.create_NTLM_NEGOTIATE_MESSAGE("domain\\username").decode('ascii')
+REQUEST_2 = 'NTLM {0!s}'.format(ntlm.create_NTLM_NEGOTIATE_MESSAGE("domain\\username").decode('ascii'))
 
 RESPONSE_2 = 'NTLM TlRMTVNTUAACAAAADAAMADAAAAAHAgMAESIzRFVmd4gAAAAAAAAAAGIAYgA8AAAARABPAE0AQQBJAE4AAgAMAEQATwBNAEEASQBOAAEADABTAEUAUgBWAEUAUgAEABYAZQB4AGEAbQBwAGwAZQAuAGMAbwBtAAMAJABTAEUAUgBWAEUAUgAuAGUAeABhAG0AcABsAGUALgBjAG8AbQAAAAAA'
 ServerChallenge, NegotiateFlags = ntlm.parse_NTLM_CHALLENGE_MESSAGE(RESPONSE_2[5:])
 
-REQUEST_3 = 'NTLM %s' % ntlm.create_NTLM_AUTHENTICATE_MESSAGE(ServerChallenge, 'username', 'domain', 'password', NegotiateFlags).decode('ascii')
+REQUEST_3 = 'NTLM {0!s}'.format(ntlm.create_NTLM_AUTHENTICATE_MESSAGE(ServerChallenge, 'username', 'domain', 'password', NegotiateFlags).decode('ascii'))
 
 @app.route("/")
 def ntlm_auth():


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:requests-ntlm?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vmuriart:requests-ntlm?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
